### PR TITLE
Add constructor documentation in DetailController

### DIFF
--- a/src/Controller/DetailController.php
+++ b/src/Controller/DetailController.php
@@ -13,6 +13,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
 final class DetailController extends AbstractController
 {
+    // Le constructeur permet de ne pas avoir à passer les dépendances en paramètres
     public function __construct(
         private EntityManagerInterface $em,
         private DetailRepository $dr


### PR DESCRIPTION
This pull request includes a small change to the `src/Controller/DetailController.php` file. 

The change adds a comment explaining the purpose of the constructor, which is to avoid passing dependencies as parameters.